### PR TITLE
[tide]Different connection color if root or ssh

### DIFF
--- a/functions/_tide_prompt.fish
+++ b/functions/_tide_prompt.fish
@@ -4,7 +4,13 @@ function _tide_prompt
 
     test "$tide_print_newline_before_prompt" = 'true' && printf '%b' '\n'
 
-    set_color $tide_prompt_connection_color
+    if set -q SSH_TTY
+      set_color $tide_context_ssh_color
+    else if test $USER = 'root'
+      set_color --bold red
+    else
+      set_color $tide_prompt_connection_color
+    end
     test -n "$tide_prompt_connection_icon" || set -l tide_prompt_connection_icon ' '
     string repeat --no-newline --max $COLUMNS $tide_prompt_connection_icon
     printf '%b' '\r'


### PR DESCRIPTION
#### Description

Change the color and style of the prompt connection characters depending on the context.

#### Motivation and Context

Got this previously on my bash prompt and found that useful as the user information is at the right and might be not catched at first glance. Setting the color obviously showing you that you are using the root account or that you are on a remote connection.

#### How Has This Been Tested

- [X] I have tested using **Linux**.
- [ ] I have tested using **MacOS**.

#### Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
